### PR TITLE
Use Number.isNaN

### DIFF
--- a/cheats.js
+++ b/cheats.js
@@ -343,7 +343,7 @@ ig.module("cheats-gui").requires("game.feature.gui.screen.title-screen", "game.f
 						}
 						case "SLIDER": {
 							const num = Number(value);
-							if (num !== NaN) {
+							if (!Number.isNaN(num)) {
 								const clamped = Math.max(cheatData.min, Math.min(cheatData.max, num));
 								setCheatValue(cheat, clamped);
 							}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "Cheats",
 	"postload": "cheats.js",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"homepage": "https://github.com/ZeikJT/CrossCodeCheats",
 	"description": "This mod adds cheats to CrossCode.",
 	"ccmodDependencies": {


### PR DESCRIPTION
You can't actually do a comparison against NaN because there are too many calculations that can result in different NaNs.
Fun experiment in the console: `NaN !== NaN`
It's the only value in javascript with this property! You can make a NaN detector with a simple function:
```
function isNaN(value) {
  return value !== value
}
```