### PR TITLE
Change version support to be 1.2 minimum, no maximum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "Cheats",
 	"postload": "cheats.js",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"homepage": "https://github.com/ZeikJT/CrossCodeCheats",
 	"description": "This mod adds cheats to CrossCode.",
 	"ccmodDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
 	"description": "This mod adds cheats to CrossCode.",
 	"ccmodDependencies": {
 		"ccloader": "^2.11.0",
-		"crosscode": "1.2 - 1.3"
+		"crosscode": ">=1.2"
 	}
 }


### PR DESCRIPTION
I won't be able to feasibly test each version as they come out so just optimistically support them all and if any are buggy hopefully people will file issues.